### PR TITLE
[FEAT] override only if nxt is not empty

### DIFF
--- a/deepmerge/strategy/type_conflict.py
+++ b/deepmerge/strategy/type_conflict.py
@@ -15,3 +15,8 @@ class TypeConflictStrategies(StrategyList):
     def strategy_use_existing(config, path, base, nxt):
         """ overrides the new object over the old object """
         return base
+
+    @staticmethod
+    def strategy_override_if_not_empty(config, path, base, nxt):
+        """ overrides the new object over the old object """
+        return nxt if nxt else base

--- a/deepmerge/strategy/type_conflict.py
+++ b/deepmerge/strategy/type_conflict.py
@@ -13,10 +13,10 @@ class TypeConflictStrategies(StrategyList):
 
     @staticmethod
     def strategy_use_existing(config, path, base, nxt):
-        """ overrides the new object over the old object """
+        """ uses the old object instead of the new object """
         return base
 
     @staticmethod
     def strategy_override_if_not_empty(config, path, base, nxt):
-        """ overrides the new object over the old object """
+        """ overrides the new object over the old object only if the new object is not empty or null """
         return nxt if nxt else base

--- a/deepmerge/tests/strategy/test_type_conflict.py
+++ b/deepmerge/tests/strategy/test_type_conflict.py
@@ -1,0 +1,16 @@
+from deepmerge.strategy.type_conflict import TypeConflictStrategies
+
+EMPTY_DICT = {}
+
+CONTENT_AS_LIST = [{"key": "val"}]
+
+
+def test_merge_if_not_empty():
+    strategy = TypeConflictStrategies.strategy_override_if_not_empty({}, [], EMPTY_DICT, CONTENT_AS_LIST)
+    assert strategy == CONTENT_AS_LIST
+
+    strategy = TypeConflictStrategies.strategy_override_if_not_empty({}, [], CONTENT_AS_LIST, EMPTY_DICT)
+    assert strategy == CONTENT_AS_LIST
+
+    strategy = TypeConflictStrategies.strategy_override_if_not_empty({}, [], CONTENT_AS_LIST, None)
+    assert strategy == CONTENT_AS_LIST


### PR DESCRIPTION
When using "deepmerge" on complex logic, for example merging many YAML/JSON/etc files, there are use-cases where the developer would prefer to override only if there is content, else stay with the current config.