### PR TITLE
ListStrategy to append unduplicated

### DIFF
--- a/deepmerge/strategy/list.py
+++ b/deepmerge/strategy/list.py
@@ -22,3 +22,8 @@ class ListStrategies(StrategyList):
     def strategy_append(config, path, base, nxt):
         """ append nxt to base. """
         return base + nxt
+
+    @staticmethod
+    def strategy_append_unduplicated(config, path, base, nxt):
+        """ append unduplicated items in nxt to base. """
+        return base + [n for n in nxt if n not in base]

--- a/deepmerge/tests/strategy/test_list.py
+++ b/deepmerge/tests/strategy/test_list.py
@@ -1,0 +1,23 @@
+import pytest
+from deepmerge.strategy.list import ListStrategies
+from deepmerge import Merger
+
+
+@pytest.fixture
+def custom_merger():
+    return Merger(
+        [
+            (list, ListStrategies.strategy_append_unduplicated)
+        ],
+        [],
+        [],
+    )
+
+
+def test_strategy_append_unduplicated(custom_merger):
+    base = [1, 3, 2]
+    nxt = [3, 5, 4, 1, 2]
+
+    expected = [1, 3, 2, 5, 4]
+    actual = custom_merger.merge(base, nxt)
+    assert actual == expected


### PR DESCRIPTION
Hello,

Thanks for offering a convenient library. I used it for my project and I'd like to add a new ListStrategy which adds items without conflicts with the base list. the following is an example of usage. 

```
class Mymerger(Merger):
    def __init__(self):
        super().__init__(
            # strategies for specific types
            [
                (list, ["append_unduplicated"]),
                (dict, ["merge"])
            ],
            # fallback strategies, applied to all other types:
            ["override"],
            # starategis, when conflicted:
            ["override"]
        )

base = {"a": ["a", "b"]}
next = {"b": "a", "a": ["b", "c"]}

Mymerger().merge(base, next)
# -> {"a": ["a", "b", "c"], "b": "a"}
```

Since I didn't find a good place to place a test, I didn't write any. But, you could ask me