### PR TITLE
Include data in `InvalidMerge` exception class

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 deepmerge
 =========
 
-.. image:: https://travis-ci.org/toumorokoshi/deepmerge.svg?branch=masterhttps://travis-ci.org/toumorokoshi/deepmerge.svg?branch=master
+.. image:: https://travis-ci.org/toumorokoshi/deepmerge.svg?branch=master
     :target: https://travis-ci.org/toumorokoshi/deepmerge
 
 A tools to handle merging of

--- a/deepmerge/exception.py
+++ b/deepmerge/exception.py
@@ -8,7 +8,7 @@ class StrategyNotFound(DeepMergeException):
 
 class InvalidMerge(DeepMergeException):
     def __init__(self, strategy_list_name, merge_args, merge_kwargs):
-        super().__init__("no more strategies found for {0} and arguments {1}, {2}".format(strategy_list_name, merge_args, merge_kwargs))
+        super(InvalidMerge, self).__init__("no more strategies found for {0} and arguments {1}, {2}".format(strategy_list_name, merge_args, merge_kwargs))
         self.strategy_list_name = strategy_list_name
         self.merge_args = merge_args
         self.merge_kwargs = merge_kwargs

--- a/deepmerge/exception.py
+++ b/deepmerge/exception.py
@@ -7,4 +7,8 @@ class StrategyNotFound(DeepMergeException):
 
 
 class InvalidMerge(DeepMergeException):
-    pass
+    def __init__(self, strategy_list_name, merge_args, merge_kwargs):
+        super().__init__("no more strategies found for {0} and arguments {1}, {2}".format(strategy_list_name, merge_args, merge_kwargs))
+        self.strategy_list_name = strategy_list_name
+        self.merge_args = merge_args
+        self.merge_kwargs = merge_kwargs

--- a/deepmerge/strategy/core.py
+++ b/deepmerge/strategy/core.py
@@ -37,6 +37,4 @@ class StrategyList(object):
             ret_val = s(*args, **kwargs)
             if ret_val is not STRATEGY_END:
                 return ret_val
-        raise InvalidMerge("no more strategies found for {0} and arguments {1}, {2}".format(
-            self.NAME, args, kwargs
-        ))
+        raise InvalidMerge(self.NAME, args, kwargs)

--- a/deepmerge/tests/test_full.py
+++ b/deepmerge/tests/test_full.py
@@ -1,4 +1,7 @@
+from deepmerge.exception import *
 import pytest
+
+
 from deepmerge import (
     always_merger,
     conservative_merger,
@@ -29,8 +32,12 @@ def test_merge_or_raise_raises_exception():
         "bar": 1,
         "foo": "a string!"
     }
-    with pytest.raises(Exception):
+    with pytest.raises(InvalidMerge, match=r"^no more strategies found for type conflict and arguments \(<deepmerge.merger.Merger object at 0x[0-9a-f]+>, \['foo'\], 0, 'a string!'\), {}$") as exc_info:
         merge_or_raise.merge(base, nxt)
+    exc = exc_info.value
+    assert exc.strategy_list_name == "type conflict"
+    assert exc.merge_args == (merge_or_raise, ["foo"], 0, "a string!")
+    assert exc.merge_kwargs == {}
 
 
 @pytest.mark.parametrize("base, nxt, expected", [
@@ -51,5 +58,3 @@ def test_example():
         "bar": "value2",
         "baz": ["a", "b"]
     }
-
-     

--- a/deepmerge/tests/test_full.py
+++ b/deepmerge/tests/test_full.py
@@ -32,7 +32,7 @@ def test_merge_or_raise_raises_exception():
         "bar": 1,
         "foo": "a string!"
     }
-    with pytest.raises(InvalidMerge, match=r"^no more strategies found for type conflict and arguments \(<deepmerge.merger.Merger object at 0x[0-9a-f]+>, \['foo'\], 0, 'a string!'\), {}$") as exc_info:
+    with pytest.raises(InvalidMerge) as exc_info:
         merge_or_raise.merge(base, nxt)
     exc = exc_info.value
     assert exc.strategy_list_name == "type conflict"


### PR DESCRIPTION
This allows for programmatic access to the data reflected by an `InvalidMerge` exception, and not just a string representation (though this is preserved too).