### PR TITLE
stop supporting python2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 sudo: false
 language: python
 python:
-  - "2.7"
+  - "3.6"
   - "3.7"
-  - "pypy"
+  - "3.8"
+  - "3.9"
+  - "pypy3"
 
 script: "./uranium test"

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     author="Yusuke Tsutsumi",
     author_email="yusuke@tsutsumi.io",
     url="http://deepmerge.readthedocs.io/en/latest/",
+    python_requires=">=3",
     packages=find_packages(exclude=["tests*", "*.tests*"]),
     install_requires=install_requires,
     classifiers=[


### PR DESCRIPTION
Python2.7 is EOL as of January 1st, 2020.

Also adding additional python versions to test
against, as 3.7 is a bit old now (2018 first release).