### PR TITLE
Adding pypi release via Github actions

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -38,3 +38,8 @@ jobs:
     - name: test
       run: |
         make test
+    - name: pypi-release
+      if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.python-version == '3.10' }}
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This workflow ensures that tags on GitHub will always be published
approrpiately along with pypi releases, avoiding #17 in the future.