### PR TITLE
minor: updating python-package to run on all push

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -6,6 +6,8 @@ name: Python package
 on:
   push:
     branches: [ master ]
+    tags:
+    - 'v*'
   pull_request:
     branches: [ master ]
 
@@ -38,8 +40,3 @@ jobs:
     - name: test
       run: |
         make test
-    - name: pypi-release
-      if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.python-version == '3.10' }}
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
GitHub actions didn't trigger after pushing a tag, presumably
because it only acknowledge the master branch.