### PR TITLE
Fix documentation for custom strategies

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -80,7 +80,7 @@ Custom Strategies
 Strategies are functions that satisfy the following properties:
 
 * have the function signature (config, path, base, nxt)
-* return the merged object, or None.
+* return the merged object, or `deepmerge.STRATEGY_END`.
 
 Example:
 
@@ -92,7 +92,7 @@ Example:
           base.append(nxt[-1])
           return base
 
-If a strategy fails, an exception should not be raised. This is to
+If a strategy fails, an exception should not be raised, instead it should return `deepmerge.STRATEGY_END`. This is to
 ensure it can be chained with other strategies, or the fall-back.
 
 Uniqueness of elements when merging


### PR DESCRIPTION
Currently, the documentation suggests that if a strategy fails it should return `None` in order to allow other strategies to be applied.

This is not the case, since returning `None` will be treated as a successful merge, instead, the code expects `deepmerge.STRATEGY_END`:

https://github.com/toumorokoshi/deepmerge/blob/c96610a9c63051c4e22eca71da5ce5fc9ce4ea64/deepmerge/strategy/core.py#L33-L38

This PR fixes the documentation accordingly. 
