### PR TITLE
Make predefined merge strategies work with built-in collections subtypes

### DIFF
--- a/deepmerge/merger.py
+++ b/deepmerge/merger.py
@@ -36,9 +36,9 @@ class Merger(object):
         return self._type_conflict_strategy(self, *args)
 
     def value_strategy(self, path, base, nxt):
+        for typ, strategy in self._type_strategies:
+            if isinstance(base, typ) and isinstance(nxt, typ):
+                return strategy(self, path, base, nxt)
         if not (isinstance(base, type(nxt)) or isinstance(nxt, type(base))):
             return self.type_conflict_strategy(path, base, nxt)
-        for typ, strategy in self._type_strategies:
-            if isinstance(nxt, typ):
-                return strategy(self, path, base, nxt)
         return self._fallback_strategy(self, path, base, nxt)

--- a/deepmerge/tests/test_full.py
+++ b/deepmerge/tests/test_full.py
@@ -1,4 +1,5 @@
 from deepmerge.exception import *
+from collections import OrderedDict, defaultdict
 import pytest
 
 
@@ -48,3 +49,12 @@ def test_example():
     always_merger.merge(base, next)
 
     assert base == {"foo": "value", "bar": "value2", "baz": ["a", "b"]}
+
+
+def test_subtypes():
+    base = OrderedDict({"foo": "value", "baz": ["a"]})
+    next = defaultdict(str, {"bar": "value2", "baz": ["b"]})
+
+    result = always_merger.merge(base, next)
+
+    assert dict(result) == {"foo": "value", "bar": "value2", "baz": ["a", "b"]}


### PR DESCRIPTION
Currently the predefined merge strategies for dicts, lists and sets are not being applied when the objects to be merged are different subtypes of those base types.

For instance, two dicts can be merged. Even a dict with an OrderedDict, or viceversa. But an OrderedDict and a defaultdict are treated as two completely different types and the conflict strategy is applied, although they could perfectly be merged as dicts, as they are both subtypes of dict and behave as such.

This PR allows subtypes of the base collections to be merged according to the strategies defined for them.