### PR TITLE
Update Python versions

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v2
@@ -34,14 +34,14 @@ jobs:
       run: |
         make build
     - name: lint
-      if: ${{ matrix.python-version == '3.10' }}
+      if: ${{ matrix.python-version == '3.12' }}
       run: |
         make lint
     - name: test
       run: |
         make test
     - name: pypi-release
-      if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.python-version == '3.10' }}
+      if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.python-version == '3.12' }}
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Update Python versions to those supported by GitHub Actions. Currently, Python 2.7 is causing this error in the Python package build job (e.g. in #25):
```
Warning: The support for python 2.7 will be removed on June 19. Related issue: https://github.com/actions/setup-python/issues/672
Version 2.7 was not found in the local cache
Error: Version 2.7 with arch x[6](https://github.com/toumorokoshi/deepmerge/actions/runs/7224927610/job/19711710348?pr=25#step:4:7)4 not found
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```