### PR TITLE
Remove redundant black config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,4 +63,3 @@ write_to = "deepmerge/_version.py"
 
 [tool.black]
 line-length = 100
-target-version = ["py38", "py39", "py310", "py311", "py312"]


### PR DESCRIPTION
Per [black docs](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html)

> By default, Black will infer target versions from the project metadata in pyproject.toml, specifically the [project.requires-python] field.