### PR TITLE
fix: Different hash for same dictionaries problem

### DIFF
--- a/deepmerge/extended_set.py
+++ b/deepmerge/extended_set.py
@@ -23,8 +23,8 @@ class ExtendedSet(set):
         if getattr(element, "__hash__") is not None:
             return hash(element)
         elif isinstance(element, dict):
-            sorted_keys = sorted(element.keys())  # sorting keys
-            return hash(','.join([f'{key}:{element[key]}' for key in sorted_keys]))  # building str based on the sorted keys
+            sorted_keys = sorted(element.keys())
+            return hash(",".join([f"{key}:{element[key]}" for key in sorted_keys]))
         return hash(str(element))
 
     def __contains__(self, obj: Any) -> bool:

--- a/deepmerge/extended_set.py
+++ b/deepmerge/extended_set.py
@@ -22,6 +22,9 @@ class ExtendedSet(set):
     def _hash_element(self, element: Any) -> int:
         if getattr(element, "__hash__") is not None:
             return hash(element)
+        elif isinstance(element, dict):
+            sorted_keys = sorted(element.keys())  # sorting keys
+            return hash(','.join([f'{key}:{element[key]}' for key in sorted_keys]))  # building str based on the sorted keys
         return hash(str(element))
 
     def __contains__(self, obj: Any) -> bool:


### PR DESCRIPTION
When merging unhashable types, the hash is calculated based on `str(obj)`. 
The problem appears when the hash is being calculated for two dictionaries like 
`{'foo': 1, 'bar': 2}` and
`{'bar': 2, 'foo': 1}`
In this case, the calculated hashes don't match, though from any other perspective, the dictionaries have no difference.
I'd suggest sorting keys in the dictionary alphabetically on the dict->str conversion.

I'm not a professional programmer so please check whether my logic is valid and if nothing is broken.
`make ready-pr` passed.
