### PR TITLE
minor: add __all__ to strategy __init__

### DIFF
--- a/deepmerge/strategy/__init__.py
+++ b/deepmerge/strategy/__init__.py
@@ -4,3 +4,15 @@ from .fallback import FallbackStrategies
 from .list import ListStrategies
 from .set import SetStrategies
 from .type_conflict import TypeConflictStrategies
+
+__all__ = [
+    'StrategyList',
+    'StrategyCallable',
+    'StrategyListInitable',
+    'DictStrategies',
+    'FallbackStrategies',
+    'ListStrategies',
+    'SetStrategies',
+    'TypeConflictStrategies',
+]
+

--- a/deepmerge/strategy/__init__.py
+++ b/deepmerge/strategy/__init__.py
@@ -6,13 +6,12 @@ from .set import SetStrategies
 from .type_conflict import TypeConflictStrategies
 
 __all__ = [
-    'StrategyList',
-    'StrategyCallable',
-    'StrategyListInitable',
-    'DictStrategies',
-    'FallbackStrategies',
-    'ListStrategies',
-    'SetStrategies',
-    'TypeConflictStrategies',
+    "StrategyList",
+    "StrategyCallable",
+    "StrategyListInitable",
+    "DictStrategies",
+    "FallbackStrategies",
+    "ListStrategies",
+    "SetStrategies",
+    "TypeConflictStrategies",
 ]
-


### PR DESCRIPTION
Thank you for your work @toumorokoshi!

Just a little idea I had:
Instead of the recommended "magic-value-esque" way:
```python
from deepmerge.merger import Merger

merger = Merger(
    type_strategies=[(list, 'override'), (dict, 'merge'), (set, 'union')],
    fallback_strategies=['override'],
    type_conflict_strategies=['override']
)
```
I would prefer explicitly referencing the merging functions:
```python
from deepmerge.merger import Merger
from deepmerge.strategy import (
    ListStrategies,
    DictStrategies,
    SetStrategies,
    FallbackStrategies,
    TypeConflictStrategies
)

merger = Merger(
    type_strategies=[
        (list, ListStrategies.strategy_override), 
        (dict, DictStrategies.strategy_merge), 
        (set, SetStrategies.strategy_union)
    ],
    fallback_strategies=[
        FallbackStrategies.strategy_override
    ],
    type_conflict_strategies=[
        TypeConflictStrategies.strategy_override
    ]
)
```

This exact code does run currently, although the type checkers report errors:
```
"ListStrategies" is not exported from module "deepmerge.strategy"
     Import from "deepmerge.strategy.list" instead [reportPrivateImportUsage]
```
The suggested form would require a whole bunch of import lines.

Same applies to the merger.py source code:
```
"ListStrategies" is not exported from module "..strategy" [reportPrivateImportUsage]
```

Listing the classes in the \_\_all\_\_ variable solves this.