### PR TITLE
fix: compare by equality, not just hash, in ExtendedSet

### DIFF
--- a/deepmerge/extended_set.py
+++ b/deepmerge/extended_set.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Any
+from typing import Sequence, Any, Dict, List
 
 
 class ExtendedSet(set):
@@ -13,10 +13,18 @@ class ExtendedSet(set):
     """
 
     def __init__(self, elements: Sequence) -> None:
-        self._values_by_hash = {self._hash_element(e): e for e in elements}
+        # Elements are grouped into buckets keyed by their (possibly lossy)
+        # hash. Membership and insertion compare a candidate against the
+        # members of the matching bucket using equality, so two distinct
+        # elements that merely collide on the hash are not treated as equal.
+        self._buckets: Dict[int, List[Any]] = {}
+        for element in elements:
+            self._insert(element)
 
     def _insert(self, element: Any) -> None:
-        self._values_by_hash[self._hash_element(element)] = element
+        bucket = self._buckets.setdefault(self._hash_element(element), [])
+        if not any(element == existing for existing in bucket):
+            bucket.append(element)
         return
 
     def _hash_element(self, element: Any) -> int:
@@ -29,4 +37,7 @@ class ExtendedSet(set):
             return hash(str(element))
 
     def __contains__(self, obj: Any) -> bool:
-        return self._hash_element(obj) in self._values_by_hash
+        bucket = self._buckets.get(self._hash_element(obj))
+        if bucket is None:
+            return False
+        return any(obj == existing for existing in bucket)

--- a/deepmerge/strategy/fallback.py
+++ b/deepmerge/strategy/fallback.py
@@ -5,7 +5,6 @@ from typing import Any, TypeVar
 import deepmerge.merger
 from .core import StrategyList
 
-
 T = TypeVar("T")
 
 

--- a/deepmerge/tests/strategy/test_list.py
+++ b/deepmerge/tests/strategy/test_list.py
@@ -43,3 +43,23 @@ def test_strategy_append_similar_dict(custom_merger):
     result = custom_merger.merge(base, nxt)
 
     assert result == [{"bar": "bob", "foo": "baz"}, {"x": "y"}]
+
+
+def test_strategy_append_unique_keeps_hash_colliding_dicts(custom_merger):
+    """append_unique must keep distinct dicts even when their lossy
+    "key:value" hash collides (e.g. ``{"a": "1", "b": "2"}`` and
+    ``{"a": "1,b:2"}`` both hash to ``"a:1,b:2"``), and must not treat an
+    ``int`` value as equal to its ``str`` form.
+    """
+    assert custom_merger.merge([{"a": "1", "b": "2"}], [{"a": "1,b:2"}]) == [
+        {"a": "1", "b": "2"},
+        {"a": "1,b:2"},
+    ]
+    assert custom_merger.merge([{"k": 1}], [{"k": "1"}]) == [{"k": 1}, {"k": "1"}]
+
+
+def test_strategy_append_unique_hashable_hash_collision(custom_merger):
+    """A hashable element must not be considered present just because a
+    different element shares its hash (e.g. ``hash(-1) == hash(-2)``).
+    """
+    assert custom_merger.merge([-1], [-2]) == [-1, -2]


### PR DESCRIPTION
## Summary

The `append_unique` list strategy silently drops genuinely-distinct elements when they collide on a hash. `ExtendedSet.__contains__` decides membership purely from the element's hash and never checks equality, and `_hash_element` builds a lossy `"key:value"` string for dicts:

```python
from deepmerge import Merger
m = Merger([(list, ["append_unique"])], ["override"], ["override"])

m.merge([{"a": "1", "b": "2"}], [{"a": "1,b:2"}])
# -> [{'a': '1', 'b': '2'}]            # second dict dropped; expected both kept
```

Three independent collision classes, all silently wrong:

| case | hash collision | result (before) | expected |
|------|----------------|-----------------|----------|
| `{"a": "1", "b": "2"}` vs `{"a": "1,b:2"}` | both → `"a:1,b:2"` | one dropped | both kept |
| `{"k": 1}` vs `{"k": "1"}` | both → `"k:1"` | one dropped | both kept |
| `-1` vs `-2` | `hash(-1) == hash(-2) == -2` | `-2 in ExtendedSet([-1])` is `True` | `False` |

## Cause

`ExtendedSet` stored a single `{hash: element}` mapping and `__contains__` returned `self._hash_element(obj) in self._values_by_hash` — a hash-only comparison. Equality was never consulted, so any hash collision (including the lossy dict-string hash) aliased distinct values together.

## Fix

Group elements into hash-keyed **buckets** (`dict[int, list]`) and verify true `==` against the bucket members on both insert and lookup. The hash is only a bucket key; equality is the arbiter. No public API change.

This preserves the existing intended behavior — equal dicts still dedupe regardless of key order (`test_strategy_append_similar_dict`) and distinct dicts are still both kept (`test_strategy_append_unique_nested_dict`).

## Verification

- Added `test_strategy_append_unique_keeps_hash_colliding_dicts` and `test_strategy_append_unique_hashable_hash_collision`, covering all three collision classes. They fail before the fix and pass after.
- Full suite: **19 passed**. `black --check`, `mypy`, and the existing `append_unique`/`append_similar` tests all pass.

This pull request was prepared with the assistance of AI, under my direction and review.
